### PR TITLE
fix typo in practical 3

### DIFF
--- a/Practical_III/CSC3831_Practical_III.ipynb
+++ b/Practical_III/CSC3831_Practical_III.ipynb
@@ -247,7 +247,7 @@
         "ax[0].scatter(outliers[:,0], outliers[:,1], edgecolor=\"k\")\n",
         "ax[0].scatter(centers[:,0], centers[:,1], edgecolor=\"k\")\n",
         "ax[0].set_title(\"Clusters with Outliers\")\n",
-        "handles_0, legend_0 = ax[0].get_legend_hanles_lables()\n",
+        "handles_0, legend_0 = ax[0].get_legend_handles_labels()\n",
         "# ax[0].legend(handles = handles_0, labels=[\"outliers\", \"inliers\"], title=\"true class\")\n",
         "\n",
         "\n",


### PR DESCRIPTION
There is a small spelling issue with one of the graphs.